### PR TITLE
Feature: Configurable timeout

### DIFF
--- a/.gems-test
+++ b/.gems-test
@@ -1,2 +1,3 @@
 cassandra-driver -v 3.2.0
 lz4-ruby -v 0.3.3
+mocha -v 1.3.0

--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@ Simple reversible schema migrations for cassandra.
 
 ## Changelog
 
+### Version `0.3.0`
+
+- Add `query_timeout` option for running migration commands. Default 30 seconds.
+- Log relevant exception message when running migrations
+
 ### Version `0.2.0`
 
 - Refactor `schema_information` queries to use LWT and `:quorum` consistency level
@@ -65,6 +70,7 @@ migrator = CassandraSchema::Migrator.new(
   connection: CONN, # any connection object implementing `execute` method
   migrations: CassandraSchema.migrations, # list of migrations
   logger: Logger.new, # any logger object implementing `info` and `error` methods
+  options: {}, # additional configuration
 )
 ```
 
@@ -81,6 +87,15 @@ migrator.migrate(2)
 ```
 
 CassandraSchema tracks which migrations you have already run.
+
+
+### Options
+
+name | default | description
+---- | ------- | -----------
+lock | true    | whether the Migrator must lock the schema before running migrations
+lock_timeout | 30 | number of seconds for auto-unlocking schema
+query_timeout | 30 | number of seconds after which to time out the command if it hasn’t completed
 
 ## Installation
 

--- a/cassandra-schema.gemspec
+++ b/cassandra-schema.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = "cassandra-schema"
-  s.version = "0.2.0"
+  s.version = "0.3.0"
   s.summary = "Cassandra schema migrations"
   s.license = "MIT"
   s.description = "Simple reversible schema migrations for Cassandra."


### PR DESCRIPTION
Closes #5 

This PR adds a new option `query_timeout` for the Migrator. It will use it as the `timeout` for running each command. Default is `30` (driver's default is `12`)
